### PR TITLE
fix: check for generated go file

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -42,7 +42,7 @@ var rootCmd = &cobra.Command{
 		// Fetch all `.go` files in the directory
 		var files []string
 		if err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-			if filepath.Ext(path) == ".go" && filepath.Ext(path) != ".gen.go" {
+			if filepath.Ext(path) == ".go" && !strings.HasSuffix(path, ".gen.go") {
 				files = append(files, path)
 			}
 			return nil

--- a/main_test.go
+++ b/main_test.go
@@ -21,3 +21,16 @@ func TestGee(t *testing.T) {
 		t.Errorf("FAILED: want %s, got %s", want, got)
 	}
 }
+
+func TestGeeIgnoreGenFiles(t *testing.T) {
+	cmd := exec.Command("./gee", "testdata/input.gen.go")
+	got, err := cmd.Output()
+
+	if err != nil {
+		t.Fatal("failed to run command:", err)
+	}
+
+	if bytes.Compare(got, []byte("")) != 0 {
+		t.Errorf("FAILED: want %s, got %s", "", got)
+	}
+}

--- a/testdata/input.gen.go
+++ b/testdata/input.gen.go
@@ -1,0 +1,28 @@
+/*
+ Assuming some Generated file with // go:generate
+ This File should not be edited
+*/
+
+package test
+
+import "fmt"
+
+func foo() error {
+	return nil
+}
+
+func bar() (string, error) {
+	return "", nil
+}
+
+func qux() error {
+	var _ error
+	//gee:hello there
+	_ = foo()
+	//gee:
+	_ = foo()
+	//gee:general kenobi
+	bazString, _ := bar()
+	fmt.Println(bazString)
+	return nil
+}


### PR DESCRIPTION
Actually the `filepath.Ext("..../x.gen.go")` will give `.go`. i.e it give the extension after the last period.

to actually check for the generated go file we can check for the `.gen.go` suffix.