### PR TITLE
feat: create gee binary before test

### DIFF
--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+/*
+	Setup Test
+	This file will run before any other test will run.
+
+	It must named be as `setup_test.go`
+
+    We are going to build the `gee` binary here for testing
+*/
+
+func TestMain(m *testing.M) {
+
+    workingDir, err := os.Getwd();
+
+    if err != nil {
+        panic(err)
+    }
+
+    cmd := exec.Command("go", "build", "-o", "gee", workingDir)
+
+    _, err = cmd.Output()
+
+    if err != nil {
+        panic(err)
+    }
+
+    os.Exit(m.Run()) // Run all test now
+}


### PR DESCRIPTION
I notice that to run the test one must build the `gee` binary before.
like `go build .`

What this can do is build the binary before every test, so that we don't have to do it manually before every test. This will also help in CI.